### PR TITLE
Generalize epitope requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
               <label for="Dataset">Dataset</label>
               <select name="Dataset" id="dataset"></select>
             </div>
-            <div class="accordion-option">
+            <div class="accordion-option" id="condition-option">
               <label>Condition</label>
               <div class="legend" id="legend"></div>
             </div>

--- a/index.html
+++ b/index.html
@@ -72,13 +72,13 @@
             either <strong>double-click</strong> on the <em>line/point</em> plot
             or hold down the option key <kbd>⌥</kbd> and
             <strong>brush</strong> over the sites that you want to deselect. If
-            there is more than one epitope in your data, an interactive legend
-            will appear in the <em>Chart Options</em>. You can select an epitope
-            to color the protein structure with by <strong>clicking</strong> on
-            an epitope in the legend. You can remove or add epitopes to the
-            <em>line/point</em> plot by holding down the option key
-            <kbd>⌥</kbd> while <strong>clicking</strong>. You can reorient and
-            zoom into the protein structure by
+            there is more than one condition in your data, an interactive legend
+            will appear in the <em>Chart Options</em>. You can select an
+            condition to color the protein structure with by
+            <strong>clicking</strong> on an condition in the legend. You can
+            remove or add conditions to the <em>line/point</em> plot by holding
+            down the option key <kbd>⌥</kbd> while <strong>clicking</strong>.
+            You can reorient and zoom into the protein structure by
             <strong>clicking and dragging</strong> it around the window. You can
             also reset the protein structure to its original orientation by
             pressing the <kbd>R</kbd> button on your keyboard.
@@ -143,7 +143,7 @@
               <select name="Dataset" id="dataset"></select>
             </div>
             <div class="accordion-option">
-              <label>Epitope</label>
+              <label>Condition</label>
               <div class="legend" id="legend"></div>
             </div>
             <div class="accordion-option">

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
           <p>
             To configure the visualization, you can open the menu to the left to
             choose various aspects of the view including colors, summary
-            statistics, filters, and more. You can also switch between
-            experiments present in the same file.
+            statistics, filters, and more. You can also switch between datasets
+            present in the same JSON file.
           </p>
           <p>
             To use the visualization, you can zoom in and out of regions of your
@@ -139,8 +139,8 @@
           </button>
           <div class="accordion-content">
             <div class="accordion-option">
-              <label for="Experiment">Experiment</label>
-              <select name="Experiment" id="experiment"></select>
+              <label for="Dataset">Dataset</label>
+              <select name="Dataset" id="dataset"></select>
             </div>
             <div class="accordion-option">
               <label>Epitope</label>

--- a/src/chart.js
+++ b/src/chart.js
@@ -12,7 +12,7 @@ export class Chart {
   constructor(_config, _data) {
     this.config = _config;
     this.config = {
-      experiment: _config.experiment,
+      dataset: _config.dataset,
       chartEpitopes: _config.chartEpitopes,
       summary: _config.summary,
       floor: _config.floor,
@@ -373,8 +373,8 @@ export class Chart {
   updateVis() {
     let vis = this;
 
-    // Get the data for the selected experiment
-    vis.originalMutMetric = vis.data[vis.config.experiment].mut_metric_df;
+    // Get the data for the selected dataset
+    vis.originalMutMetric = vis.data[vis.config.dataset].mut_metric_df;
 
     // Mask the data based on the filters
     vis.mutMetric = vis.originalMutMetric.map((d) => {
@@ -391,7 +391,7 @@ export class Chart {
       return newRow;
     });
 
-    // Summarize and filter the experiments based on the selections and epitopes
+    // Summarize and filter the datasets based on the selections and epitopes
     vis.mutMetricSummary = summarizeMetricData(vis.mutMetric).filter((d) =>
       vis.config.chartEpitopes.includes(d.epitope)
     );
@@ -467,17 +467,17 @@ export class Chart {
     );
     // Make the color scheme for the plots
     vis.positiveColor =
-      vis.data[vis.config.experiment].epitope_colors[vis.initEpitopeSelection];
+      vis.data[vis.config.dataset].epitope_colors[vis.initEpitopeSelection];
     vis.negativeColor = invertColor(vis.positiveColor);
-    // Get the amino acid alphabet for the experiment
-    vis.alphabet = vis.data[vis.config.experiment].alphabet;
+    // Get the amino acid alphabet for the dataset
+    vis.alphabet = vis.data[vis.config.dataset].alphabet;
 
     // Define the inital heatmap wildtype residue
     vis.wildtype = vis.mutMetricHeatmap.map((d) => d.wildtype)[0];
 
     // Make a map for the sequential site to the labels used on the x-axis
     vis.siteMap = new Map();
-    Object.entries(vis.data[vis.config.experiment].sitemap).forEach((entry) => {
+    Object.entries(vis.data[vis.config.dataset].sitemap).forEach((entry) => {
       const [key, value] = entry;
       vis.siteMap.set(value.sequential_site, key);
     });
@@ -613,7 +613,7 @@ export class Chart {
       .attr("d", (d) => vis.contextArea(d.data))
       .attr(
         "fill",
-        (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
       );
 
     // Draw the FOCUS plot
@@ -631,7 +631,7 @@ export class Chart {
       .attr("d", (d) => vis.focusLine(d.data))
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
       );
     vis.focusCircleG
       .selectAll("circle")
@@ -653,7 +653,7 @@ export class Chart {
       .attr("fill", "white")
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
       )
       .attr("stroke-width", 2)
       .on("mouseover", (evt, d) => {
@@ -668,7 +668,7 @@ export class Chart {
           )
           .style(
             "border-color",
-            vis.data[vis.config.experiment].epitope_colors[d.epitope]
+            vis.data[vis.config.dataset].epitope_colors[d.epitope]
           );
       })
       .on("mousemove", (evt) => {
@@ -689,7 +689,7 @@ export class Chart {
       .filter((d) => vis.selection.map((d) => d.site).includes(d.site))
       .attr(
         "fill",
-        (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
       )
       .classed("selected", true);
 
@@ -922,7 +922,7 @@ export class Chart {
         .classed("selected", true)
         .attr(
           "fill",
-          (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+          (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
         );
 
       // Add the selected points to the selection
@@ -995,7 +995,7 @@ export class Chart {
     // Get the site information from the datum
     const site = datum.site;
     const epitope = datum.epitope;
-    vis.positiveColor = vis.data[vis.config.experiment].epitope_colors[epitope];
+    vis.positiveColor = vis.data[vis.config.dataset].epitope_colors[epitope];
     vis.negativeColor = invertColor(vis.positiveColor);
     vis.wildtype = datum.wildtype;
 
@@ -1006,7 +1006,7 @@ export class Chart {
       .attr("stroke-width", 2)
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.experiment].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
       )
       .classed("heatmap-site", false);
 
@@ -1189,7 +1189,7 @@ export class Chart {
     // Create a link to download the image
     const link = document.createElement("a");
     link.href = URL.createObjectURL(blob);
-    link.download = `${vis.config.experiment}_${vis.config.metric}_${vis.config.summary}.png`;
+    link.download = `${vis.config.dataset}_${vis.config.metric}_${vis.config.summary}.png`;
     link.click();
 
     // Remove the link

--- a/src/chart.js
+++ b/src/chart.js
@@ -13,7 +13,7 @@ export class Chart {
     this.config = _config;
     this.config = {
       dataset: _config.dataset,
-      chartEpitopes: _config.chartEpitopes,
+      chartConditions: _config.chartConditions,
       summary: _config.summary,
       floor: _config.floor,
       metric: _config.metric,
@@ -391,49 +391,49 @@ export class Chart {
       return newRow;
     });
 
-    // Summarize and filter the datasets based on the selections and epitopes
+    // Summarize and filter the datasets based on the selections and conditions
     vis.mutMetricSummary = summarizeMetricData(vis.mutMetric).filter((d) =>
-      vis.config.chartEpitopes.includes(d.epitope)
+      vis.config.chartConditions.includes(d.condition)
     );
 
-    // Group the data by epitope
-    vis.mutMetricSummaryPerEpitope = Array.from(
+    // Group the data by condition
+    vis.mutMetricSummaryPerCondition = Array.from(
       d3.group(
         // Filter to only the key columns
         vis.mutMetricSummary.map((e) => {
           return {
-            epitope: e.epitope,
+            condition: e.condition,
             site: e.site,
             [vis.config.summary]: e[vis.config.summary],
           };
         }),
-        (d) => d.epitope
+        (d) => d.condition
       ),
-      ([key, value]) => ({ epitope: key, data: value })
+      ([key, value]) => ({ condition: key, data: value })
     );
 
     // Take the data for the line plot and fill in 'null' for the summary metric if the site is not in the data
     const [minSite, maxSite] = d3.extent(vis.mutMetricSummary, (d) => d.site);
 
     // Go through each object in the data array
-    vis.mutMetricSummaryPerEpitope.forEach((obj) => {
-      let epitopeData = obj.data;
-      const epitope = obj.epitope;
-      let dataBySite = new Map(epitopeData.map((item) => [item.site, item]));
+    vis.mutMetricSummaryPerCondition.forEach((obj) => {
+      let conditionData = obj.data;
+      const condition = obj.condition;
+      let dataBySite = new Map(conditionData.map((item) => [item.site, item]));
 
       // Iterate from minSite to maxSite
       for (let site = minSite; site <= maxSite; site++) {
         // If the site is not in the dataBySite map, add it with null metric
         if (!dataBySite.has(site)) {
-          epitopeData.push({
-            epitope: epitope,
+          conditionData.push({
+            condition: condition,
             site: site,
             [vis.config.summary]: null,
           });
         }
       }
       // Sort the data by site after adding missing ones
-      epitopeData.sort((a, b) => a.site - b.site);
+      conditionData.sort((a, b) => a.site - b.site);
     });
 
     // Filter out the sites where the metric is undefined
@@ -453,21 +453,21 @@ export class Chart {
         d[vis.config.summary] ===
         d3.max(vis.mutMetricSummary, (d) => d[vis.config.summary])
     )[0].site;
-    vis.initEpitopeSelection = vis.mutMetricSummary.filter(
+    vis.initConditionSelection = vis.mutMetricSummary.filter(
       (d) =>
         d[vis.config.summary] ===
         d3.max(vis.mutMetricSummary, (d) => d[vis.config.summary])
-    )[0].epitope;
+    )[0].condition;
 
     // Initialize the heatmap data for the selected site
     vis.mutMetricHeatmap = vis.mutMetric.filter(
       (e) =>
         e.site === vis.initSiteSelection &&
-        e.epitope === vis.initEpitopeSelection
+        e.condition === vis.initConditionSelection
     );
     // Make the color scheme for the plots
     vis.positiveColor =
-      vis.data[vis.config.dataset].epitope_colors[vis.initEpitopeSelection];
+      vis.data[vis.config.dataset].condition_colors[vis.initConditionSelection];
     vis.negativeColor = invertColor(vis.positiveColor);
     // Get the amino acid alphabet for the dataset
     vis.alphabet = vis.data[vis.config.dataset].alphabet;
@@ -606,20 +606,20 @@ export class Chart {
     // Draw the CONTEXT plot
     vis.contextAreaG
       .selectAll(".context-area")
-      .data(vis.mutMetricSummaryPerEpitope, (d) => `${d.epitope}-${d.site}`)
+      .data(vis.mutMetricSummaryPerCondition, (d) => `${d.condition}-${d.site}`)
       .join("path")
       .attr("class", "context-area")
       .attr("clip-path", "url(#contextClipPath)")
       .attr("d", (d) => vis.contextArea(d.data))
       .attr(
         "fill",
-        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
       );
 
     // Draw the FOCUS plot
     vis.focusLineG
       .selectAll(".focus-line")
-      .data(vis.mutMetricSummaryPerEpitope, (d) => `${d.epitope}-${d.site}`)
+      .data(vis.mutMetricSummaryPerCondition, (d) => `${d.condition}-${d.site}`)
       .join("path")
       .attr("class", "focus-line")
       .attr("clip-path", "url(#focusClipPath)")
@@ -631,11 +631,11 @@ export class Chart {
       .attr("d", (d) => vis.focusLine(d.data))
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
       );
     vis.focusCircleG
       .selectAll("circle")
-      .data(vis.filteredMutMetricSummary, (d) => `${d.epitope}-${d.site}`)
+      .data(vis.filteredMutMetricSummary, (d) => `${d.condition}-${d.site}`)
       .join(
         (enter) =>
           enter
@@ -653,7 +653,7 @@ export class Chart {
       .attr("fill", "white")
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
       )
       .attr("stroke-width", 2)
       .on("mouseover", (evt, d) => {
@@ -668,7 +668,7 @@ export class Chart {
           )
           .style(
             "border-color",
-            vis.data[vis.config.dataset].epitope_colors[d.epitope]
+            vis.data[vis.config.dataset].condition_colors[d.condition]
           );
       })
       .on("mousemove", (evt) => {
@@ -689,7 +689,7 @@ export class Chart {
       .filter((d) => vis.selection.map((d) => d.site).includes(d.site))
       .attr(
         "fill",
-        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
       )
       .classed("selected", true);
 
@@ -699,7 +699,7 @@ export class Chart {
       .filter(
         (d) =>
           d.site === vis.initSiteSelection &&
-          d.epitope === vis.initEpitopeSelection
+          d.condition === vis.initConditionSelection
       )
       .classed("heatmap-site", true)
       .attr("r", 8)
@@ -922,7 +922,7 @@ export class Chart {
         .classed("selected", true)
         .attr(
           "fill",
-          (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+          (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
         );
 
       // Add the selected points to the selection
@@ -994,8 +994,9 @@ export class Chart {
 
     // Get the site information from the datum
     const site = datum.site;
-    const epitope = datum.epitope;
-    vis.positiveColor = vis.data[vis.config.dataset].epitope_colors[epitope];
+    const condition = datum.condition;
+    vis.positiveColor =
+      vis.data[vis.config.dataset].condition_colors[condition];
     vis.negativeColor = invertColor(vis.positiveColor);
     vis.wildtype = datum.wildtype;
 
@@ -1006,14 +1007,14 @@ export class Chart {
       .attr("stroke-width", 2)
       .attr(
         "stroke",
-        (d) => vis.data[vis.config.dataset].epitope_colors[d.epitope]
+        (d) => vis.data[vis.config.dataset].condition_colors[d.condition]
       )
       .classed("heatmap-site", false);
 
     // Highlight the selected site in the focus plot
     vis.focusPlot
       .selectAll("circle")
-      .filter((d) => d.site === site && d.epitope === epitope)
+      .filter((d) => d.site === site && d.condition === condition)
       .classed("heatmap-site", true)
       .attr("r", 8)
       .attr("stroke", "black")
@@ -1021,13 +1022,13 @@ export class Chart {
 
     // Initialize the heatmap data for the selected site
     vis.mutMetricHeatmap = vis.mutMetric.filter(
-      (e) => e.site === site && e.epitope === epitope
+      (e) => e.site === site && e.condition === condition
     );
 
     // Update the scale based on the site
     vis.xScaleHeatmap.domain([site]);
 
-    // Update the color scale based on the epitope
+    // Update the color scale based on the condition
     if (!vis.config.floor) {
       vis.colorScaleHeatmap.range([
         vis.negativeColor,

--- a/src/legend.js
+++ b/src/legend.js
@@ -19,10 +19,10 @@ export class Legend {
     // Data is a deep copy of the data
     this.data = JSON.parse(JSON.stringify(_data));
     // Initialize the visualization
-    this.initVis();
+    this.initLegend();
   }
   // Initialize the visualization
-  initVis() {
+  initLegend() {
     let vis = this;
 
     // Clear any existing legend
@@ -54,10 +54,18 @@ export class Legend {
     // Make the legend
     vis.legend = vis.svg.append("g").attr("class", "condition-legend");
 
-    vis.updateVis();
+    vis.updateLegend();
   }
-  updateVis() {
+  updateLegend() {
     let vis = this;
+
+    // If the are no conditions, don't do anything and set the display to none
+    if (!vis.data[vis.config.dataset].legend) {
+      document.getElementById("condition-option").style.display = "none";
+      return;
+    } else {
+      document.getElementById("condition-option").style.display = "block";
+    }
 
     // Get all conditions as the data for the legend
     vis.allConditions = Object.keys(
@@ -75,9 +83,9 @@ export class Legend {
     vis.svg.attr("height", vis.config.height);
     vis.background.attr("height", vis.config.height);
 
-    vis.renderVis();
+    vis.renderLegend();
   }
-  renderVis() {
+  renderLegend() {
     let vis = this;
 
     // Add a highlight-box for each condition and set the visibility to hidden

--- a/src/legend.js
+++ b/src/legend.js
@@ -12,9 +12,9 @@ export class Legend {
     this.config = {
       parentElement: _config.parentElement,
       dataset: _config.dataset,
-      proteinEpitope: _config.proteinEpitope,
-      chartEpitopes: _config.chartEpitopes,
-      name: _config.name || "epitope",
+      proteinCondition: _config.proteinCondition,
+      chartConditions: _config.chartConditions,
+      name: _config.name || "condition",
     };
     // Data is a deep copy of the data
     this.data = JSON.parse(JSON.stringify(_data));
@@ -59,15 +59,17 @@ export class Legend {
   updateVis() {
     let vis = this;
 
-    // Get all epitopes as the data for the legend
-    vis.allEpitopes = Object.keys(vis.data[vis.config.dataset].epitope_colors);
+    // Get all conditions as the data for the legend
+    vis.allConditions = Object.keys(
+      vis.data[vis.config.dataset].condition_colors
+    );
 
-    // Epitope colors
-    vis.epitopeColors = vis.data[vis.config.dataset].epitope_colors;
+    // Condition colors
+    vis.conditionColors = vis.data[vis.config.dataset].condition_colors;
 
     // Set the height based on the number of elements
     vis.config.height =
-      (vis.allEpitopes.length - 1) * vis.margin.point +
+      (vis.allConditions.length - 1) * vis.margin.point +
       vis.margin.top +
       vis.margin.bottom;
     vis.svg.attr("height", vis.config.height);
@@ -78,161 +80,161 @@ export class Legend {
   renderVis() {
     let vis = this;
 
-    // Add a highlight-box for each epitope and set the visibility to hidden
+    // Add a highlight-box for each condition and set the visibility to hidden
     vis.legend
-      .selectAll(".epitope-box")
-      .data(vis.allEpitopes, (d) => d)
+      .selectAll(".condition-box")
+      .data(vis.allConditions, (d) => d)
       .join(
         (enter) =>
           enter
             .append("rect")
-            .attr("class", "epitope-box")
+            .attr("class", "condition-box")
             .attr("x", vis.margin.left - vis.margin.point / 2)
             .attr("y", (d, i) => vis.margin.top - 10 + i * vis.margin.point)
             .attr("width", "calc(100% - 20px)")
             .attr("height", 20)
             .style("opacity", (d) =>
-              vis.config.proteinEpitope.includes(d) ? ".25" : "0"
+              vis.config.proteinCondition.includes(d) ? ".25" : "0"
             )
             .attr("ry", 4)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .on("click", (event, datum) => {
-              if (event.altKey && vis.config.chartEpitopes.includes(datum)) {
-                vis.deselectChartEpitopes(datum);
+              if (event.altKey && vis.config.chartConditions.includes(datum)) {
+                vis.deselectChartConditions(datum);
               } else if (
                 event.altKey &&
-                !vis.config.chartEpitopes.includes(datum)
+                !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartEpitopes(datum);
+                vis.selectChartConditions(datum);
               } else {
-                vis.selectProteinEpitope(datum);
+                vis.selectProteinCondition(datum);
               }
             }),
         (update) =>
           update
             // Attributes that need to be updated go here
             .attr("y", (d, i) => vis.margin.top - 10 + i * vis.margin.point)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
-              vis.config.proteinEpitope.includes(d) ? ".25" : "0"
+              vis.config.proteinCondition.includes(d) ? ".25" : "0"
             ),
         (exit) => exit.remove()
       );
 
     // Add one dot in the legend for each name.
     vis.legend
-      .selectAll(".epitope-circle")
-      .data(vis.allEpitopes, (d) => d)
+      .selectAll(".condition-circle")
+      .data(vis.allConditions, (d) => d)
       .join(
         (enter) =>
           enter
             .append("circle")
-            .attr("class", "epitope-circle")
+            .attr("class", "condition-circle")
             .attr("cx", vis.margin.left)
             .attr("cy", (d, i) => vis.margin.top + i * vis.margin.point)
             .attr("r", 7)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
-              vis.config.chartEpitopes.includes(d) ? "1" : "0.2"
+              vis.config.chartConditions.includes(d) ? "1" : "0.2"
             )
             .on("click", (event, datum) => {
-              if (event.altKey && vis.config.chartEpitopes.includes(datum)) {
-                vis.deselectChartEpitopes(datum);
+              if (event.altKey && vis.config.chartConditions.includes(datum)) {
+                vis.deselectChartConditions(datum);
               } else if (
                 event.altKey &&
-                !vis.config.chartEpitopes.includes(datum)
+                !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartEpitopes(datum);
+                vis.selectChartConditions(datum);
               } else {
-                vis.selectProteinEpitope(datum);
+                vis.selectProteinCondition(datum);
               }
             }),
         (update) =>
           update
             .attr("cy", (d, i) => vis.margin.top + i * vis.margin.point)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
-              vis.config.chartEpitopes.includes(d) ? "1" : "0.2"
+              vis.config.chartConditions.includes(d) ? "1" : "0.2"
             ),
         (exit) => exit.remove()
       );
 
     // Add one dot in the legend for each name.
     vis.legend
-      .selectAll(".epitope-label")
-      .data(vis.allEpitopes, (d) => d)
+      .selectAll(".condition-label")
+      .data(vis.allConditions, (d) => d)
       .join(
         (enter) =>
           enter
             .append("text")
-            .attr("class", "epitope-label")
+            .attr("class", "condition-label")
             .attr("x", vis.margin.left * 2)
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
             .text((d) => `${vis.config.name} ${d}`)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
-              vis.config.chartEpitopes.includes(d) ? "1" : "0.2"
+              vis.config.chartConditions.includes(d) ? "1" : "0.2"
             )
             .attr("text-anchor", "left")
             .style("alignment-baseline", "middle")
             .attr("dominant-baseline", "middle")
             .style("user-select", "none")
             .on("click", (event, datum) => {
-              if (event.altKey && vis.config.chartEpitopes.includes(datum)) {
-                vis.deselectChartEpitopes(datum);
+              if (event.altKey && vis.config.chartConditions.includes(datum)) {
+                vis.deselectChartConditions(datum);
               } else if (
                 event.altKey &&
-                !vis.config.chartEpitopes.includes(datum)
+                !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartEpitopes(datum);
+                vis.selectChartConditions(datum);
               } else {
-                vis.selectProteinEpitope(datum);
+                vis.selectProteinCondition(datum);
               }
             }),
         (update) =>
           update
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
             .text((d) => `${vis.config.name} ${d}`)
-            .style("fill", (d) => vis.epitopeColors[d])
+            .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
-              vis.config.chartEpitopes.includes(d) ? "1" : "0.2"
+              vis.config.chartConditions.includes(d) ? "1" : "0.2"
             ),
         (exit) => exit.remove()
       );
   }
-  selectProteinEpitope(datum) {
+  selectProteinCondition(datum) {
     let vis = this;
 
-    // If the selected epitope isn't in the chart selection, don't do anything
-    if (!vis.config.chartEpitopes.includes(datum)) {
+    // If the selected condition isn't in the chart selection, don't do anything
+    if (!vis.config.chartConditions.includes(datum)) {
       return;
     }
 
     // First, hide all other boxes
-    vis.legend.selectAll(".epitope-box").style("opacity", "0");
+    vis.legend.selectAll(".condition-box").style("opacity", "0");
 
-    // Select the box with the same epitope as the clicked box
+    // Select the box with the same condition as the clicked box
     vis.legend
-      .selectAll(".epitope-box")
+      .selectAll(".condition-box")
       .filter(function (d) {
         return d == datum;
       })
       .style("opacity", ".25");
-    // Update the selected epitope
-    vis.config.proteinEpitope = datum;
+    // Update the selected condition
+    vis.config.proteinCondition = datum;
 
-    // Dispatch an event to notify about the selected epitope
-    const proteinEpitopeEvent = new CustomEvent("proteinEpitopeSelected", {
-      detail: vis.config.proteinEpitope,
+    // Dispatch an event to notify about the selected condition
+    const proteinConditionEvent = new CustomEvent("proteinConditionSelected", {
+      detail: vis.config.proteinCondition,
     });
-    window.dispatchEvent(proteinEpitopeEvent);
+    window.dispatchEvent(proteinConditionEvent);
   }
-  selectChartEpitopes(datum) {
+  selectChartConditions(datum) {
     let vis = this;
 
     // Color the text labels back in
     vis.legend
-      .selectAll(".epitope-label")
+      .selectAll(".condition-label")
       .filter(function (d) {
         return d == datum;
       })
@@ -240,58 +242,60 @@ export class Legend {
 
     // Color the points back in
     vis.legend
-      .selectAll(".epitope-circle")
+      .selectAll(".condition-circle")
       .filter(function (d) {
         return d == datum;
       })
       .style("opacity", "1");
 
-    // Add this epitope to the selected epitopes
-    vis.config.chartEpitopes.push(datum);
+    // Add this condition to the selected conditions
+    vis.config.chartConditions.push(datum);
 
-    // Dispatch an event to notify about the plot epitopes
-    const chartEpitopeEvent = new CustomEvent("chartEpitopesSelected", {
-      detail: vis.config.chartEpitopes,
+    // Dispatch an event to notify about the plot conditions
+    const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
+      detail: vis.config.chartConditions,
     });
-    window.dispatchEvent(chartEpitopeEvent);
+    window.dispatchEvent(chartConditionEvent);
   }
-  deselectChartEpitopes(datum) {
+  deselectChartConditions(datum) {
     let vis = this;
 
-    // If this is the last epitope, don't deselect it
-    if (vis.config.chartEpitopes.length == 1) {
+    // If this is the last condition, don't deselect it
+    if (vis.config.chartConditions.length == 1) {
       return;
     }
 
-    // Remove this epitope from the selected epitopes
-    vis.config.chartEpitopes = vis.config.chartEpitopes.filter(function (d) {
+    // Remove this condition from the selected conditions
+    vis.config.chartConditions = vis.config.chartConditions.filter(function (
+      d
+    ) {
       return d != datum;
     });
 
-    // If this epitope is highlighted, remove the highlight and move it to the next epitope in the list
-    if (vis.config.proteinEpitope == datum) {
-      vis.selectProteinEpitope(vis.config.chartEpitopes[0]);
+    // If this condition is highlighted, remove the highlight and move it to the next condition in the list
+    if (vis.config.proteinCondition == datum) {
+      vis.selectProteinCondition(vis.config.chartConditions[0]);
     }
 
     // Add opacity to the text labels and points
     vis.legend
-      .selectAll(".epitope-label")
+      .selectAll(".condition-label")
       .filter(function (d) {
         return d == datum;
       })
       .style("opacity", ".25");
 
     vis.legend
-      .selectAll(".epitope-circle")
+      .selectAll(".condition-circle")
       .filter(function (d) {
         return d == datum;
       })
       .style("opacity", ".25");
 
-    // Dispatch an event to notify about the plot epitopes
-    const chartEpitopeEvent = new CustomEvent("chartEpitopesSelected", {
-      detail: vis.config.chartEpitopes,
+    // Dispatch an event to notify about the plot conditions
+    const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
+      detail: vis.config.chartConditions,
     });
-    window.dispatchEvent(chartEpitopeEvent);
+    window.dispatchEvent(chartConditionEvent);
   }
 }

--- a/src/legend.js
+++ b/src/legend.js
@@ -11,7 +11,7 @@ export class Legend {
     this.config = _config;
     this.config = {
       parentElement: _config.parentElement,
-      experiment: _config.experiment,
+      dataset: _config.dataset,
       proteinEpitope: _config.proteinEpitope,
       chartEpitopes: _config.chartEpitopes,
       name: _config.name || "epitope",
@@ -60,12 +60,10 @@ export class Legend {
     let vis = this;
 
     // Get all epitopes as the data for the legend
-    vis.allEpitopes = Object.keys(
-      vis.data[vis.config.experiment].epitope_colors
-    );
+    vis.allEpitopes = Object.keys(vis.data[vis.config.dataset].epitope_colors);
 
     // Epitope colors
-    vis.epitopeColors = vis.data[vis.config.experiment].epitope_colors;
+    vis.epitopeColors = vis.data[vis.config.dataset].epitope_colors;
 
     // Set the height based on the number of elements
     vis.config.height =

--- a/src/legend.js
+++ b/src/legend.js
@@ -14,7 +14,7 @@ export class Legend {
       dataset: _config.dataset,
       proteinCondition: _config.proteinCondition,
       chartConditions: _config.chartConditions,
-      name: _config.name || "condition",
+      prefix: _config.prefix || "condition",
     };
     // Data is a deep copy of the data
     this.data = JSON.parse(JSON.stringify(_data));
@@ -170,7 +170,7 @@ export class Legend {
             .attr("class", "condition-label")
             .attr("x", vis.margin.left * 2)
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
-            .text((d) => `${vis.config.name} ${d}`)
+            .text((d) => `${vis.config.prefix} ${d}`)
             .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
               vis.config.chartConditions.includes(d) ? "1" : "0.2"
@@ -194,7 +194,7 @@ export class Legend {
         (update) =>
           update
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
-            .text((d) => `${vis.config.name} ${d}`)
+            .text((d) => `${vis.config.prefix} ${d}`)
             .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
               vis.config.chartConditions.includes(d) ? "1" : "0.2"

--- a/src/legend.js
+++ b/src/legend.js
@@ -14,7 +14,7 @@ export class Legend {
       dataset: _config.dataset,
       proteinCondition: _config.proteinCondition,
       chartConditions: _config.chartConditions,
-      prefix: _config.prefix || "condition",
+      label: _config.label || "Condition",
     };
     // Data is a deep copy of the data
     this.data = JSON.parse(JSON.stringify(_data));
@@ -64,6 +64,9 @@ export class Legend {
       document.getElementById("condition-option").style.display = "none";
       return;
     } else {
+      // Select the label element inside the div with id 'condition-option'
+      const label = document.querySelector("#condition-option label");
+      label.textContent = vis.config.label;
       document.getElementById("condition-option").style.display = "block";
     }
 
@@ -178,7 +181,7 @@ export class Legend {
             .attr("class", "condition-label")
             .attr("x", vis.margin.left * 2)
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
-            .text((d) => `${vis.config.prefix} ${d}`)
+            .text((d) => `${d}`)
             .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
               vis.config.chartConditions.includes(d) ? "1" : "0.2"
@@ -202,7 +205,7 @@ export class Legend {
         (update) =>
           update
             .attr("y", (d, i) => vis.margin.top + i * vis.margin.point)
-            .text((d) => `${vis.config.prefix} ${d}`)
+            .text((d) => `${d}`)
             .style("fill", (d) => vis.conditionColors[d])
             .style("opacity", (d) =>
               vis.config.chartConditions.includes(d) ? "1" : "0.2"

--- a/src/main.js
+++ b/src/main.js
@@ -136,8 +136,8 @@ function setUpJsonFileUploadListeners() {
 
 // Set up the event listeners for the chart options
 function setUpChartOptionListeners() {
-  d3.select("#experiment").on("change", function () {
-    State.updateSelectedExperiment(this);
+  d3.select("#dataset").on("change", function () {
+    State.updateSelectedDataset(this);
     // Reize the accordion menu if necessary (i.e. legend size changes)
     let btn = document.getElementById("chart-btn");
     if (btn.classList.contains("is-open")) {

--- a/src/main.js
+++ b/src/main.js
@@ -145,11 +145,11 @@ function setUpChartOptionListeners() {
       content.style.maxHeight = content.scrollHeight + "px";
     }
   });
-  window.addEventListener("proteinEpitopeSelected", function (event) {
-    State.updateProteinEpitope(event.detail);
+  window.addEventListener("proteinConditionSelected", function (event) {
+    State.updateProteinCondition(event.detail);
   });
-  window.addEventListener("chartEpitopesSelected", function (event) {
-    State.updateChartEpitopes(event.detail);
+  window.addEventListener("chartConditionsSelected", function (event) {
+    State.updateChartConditions(event.detail);
   });
   d3.select("#summary").on("change", function () {
     State.updateChartOptions(this);

--- a/src/protein.js
+++ b/src/protein.js
@@ -184,7 +184,7 @@ export class Protein {
     // Summarize the data
     protein.mutMetric = protein.data[protein.config.dataset].mut_metric_df;
     protein.mutMetricSummary = summarizeMetricData(protein.mutMetric).filter(
-      (e) => e.epitope === protein.config.proteinEpitope
+      (e) => e.condition === protein.config.proteinCondition
     );
 
     // Set up the accessor function
@@ -196,8 +196,8 @@ export class Protein {
 
     // Update the color scale
     const positiveColor =
-      protein.data[protein.config.dataset].epitope_colors[
-        protein.config.proteinEpitope
+      protein.data[protein.config.dataset].condition_colors[
+        protein.config.proteinCondition
       ];
     const negativeColor = invertColor(positiveColor);
     const metricExtent = d3
@@ -342,7 +342,7 @@ export class Protein {
           (now.getMonth() + 1).toString().padStart(2, "0") +
           "-" +
           now.getDate().toString().padStart(2, "0");
-        let fileName = `${protein.config.dataset}_${protein.config.proteinEpitope}_${dateString}.png`;
+        let fileName = `${protein.config.dataset}_${protein.config.proteinCondition}_${dateString}.png`;
         NGL.download(blob, fileName);
       });
   }

--- a/src/protein.js
+++ b/src/protein.js
@@ -86,8 +86,8 @@ export class Protein {
     }
 
     // Get the chain selections for the protein structure
-    let dataChains = protein.data[protein.config.experiment].dataChains;
-    let excludeChains = protein.data[protein.config.experiment].excludeChains;
+    let dataChains = protein.data[protein.config.dataset].dataChains;
+    let excludeChains = protein.data[protein.config.dataset].excludeChains;
 
     // Make the selection of chains to include in the protein structure
     if (dataChains != "polymer") {
@@ -182,7 +182,7 @@ export class Protein {
     let protein = this;
 
     // Summarize the data
-    protein.mutMetric = protein.data[protein.config.experiment].mut_metric_df;
+    protein.mutMetric = protein.data[protein.config.dataset].mut_metric_df;
     protein.mutMetricSummary = summarizeMetricData(protein.mutMetric).filter(
       (e) => e.epitope === protein.config.proteinEpitope
     );
@@ -196,7 +196,7 @@ export class Protein {
 
     // Update the color scale
     const positiveColor =
-      protein.data[protein.config.experiment].epitope_colors[
+      protein.data[protein.config.dataset].epitope_colors[
         protein.config.proteinEpitope
       ];
     const negativeColor = invertColor(positiveColor);
@@ -342,7 +342,7 @@ export class Protein {
           (now.getMonth() + 1).toString().padStart(2, "0") +
           "-" +
           now.getDate().toString().padStart(2, "0");
-        let fileName = `${protein.config.experiment}_${protein.config.proteinEpitope}_${dateString}.png`;
+        let fileName = `${protein.config.dataset}_${protein.config.proteinEpitope}_${dateString}.png`;
         NGL.download(blob, fileName);
       });
   }

--- a/src/tool.js
+++ b/src/tool.js
@@ -22,8 +22,8 @@ export class Tool {
 
     // Format the data for each dataset in the JSON file
     for (const dataset in tool.data) {
-      // If the dataset doesn't have any 'conditions' set it to default
-      if (!tool.data[dataset].conditions) {
+      // Check if conditions_col is null
+      if (tool.data[dataset].condition_col === null) {
         tool.data[dataset].conditions = ["default"];
         // Set the legend to false because there is only one condition
         tool.data[dataset].legend = false;
@@ -37,18 +37,21 @@ export class Tool {
       // Get the map for reference sites to sequential sites
       const siteMap = tool.data[dataset].sitemap;
       // Get the column name of the mutation-level metric
-      const metric = tool.data[dataset].metric_col;
+      const metric_col = tool.data[dataset].metric_col;
+      // Get the name of the condition column
+      const condition_col = tool.data[dataset].condition_col;
       // Map the reference sites to sequential and protein sites
       tool.data[dataset].mut_metric_df = tool.data[dataset].mut_metric_df.map(
         (e) => {
-          const condition = e.condition ? e.condition.toString() : "default";
+          const condition =
+            condition_col !== null ? e[condition_col].toString() : "default";
           return {
             ...e,
             site: siteMap[e.reference_site].sequential_site,
             site_reference: e.reference_site,
             site_protein: siteMap[e.reference_site].protein_site,
             site_chain: siteMap[e.reference_site].chains,
-            metric: e[metric],
+            metric: e[metric_col],
             condition: condition,
           };
         }
@@ -86,7 +89,7 @@ export class Tool {
         dataset: tool.dataset,
         proteinCondition: tool.proteinCondition,
         chartConditions: tool.chartConditions,
-        prefix: "epitope",
+        label: tool.data[tool.dataset].condition_col,
       },
       tool.data
     );

--- a/src/tool.js
+++ b/src/tool.js
@@ -22,10 +22,18 @@ export class Tool {
 
     // Format the data for each dataset in the JSON file
     for (const dataset in tool.data) {
-      // Get the conditions for the dataset and convert to strings
-      tool.data[dataset].conditions = tool.data[dataset].conditions.map((e) =>
-        e.toString()
-      );
+      // If the dataset doesn't have any 'conditions' set it to default
+      if (!tool.data[dataset].conditions) {
+        tool.data[dataset].conditions = ["default"];
+        // Set the legend to false because there is only one condition
+        tool.data[dataset].legend = false;
+      } else {
+        // Get the conditions for the dataset and convert to strings
+        tool.data[dataset].conditions = tool.data[dataset].conditions.map((e) =>
+          e.toString()
+        );
+        tool.data[dataset].legend = true;
+      }
       // Get the map for reference sites to sequential sites
       const siteMap = tool.data[dataset].sitemap;
       // Get the column name of the mutation-level metric
@@ -33,6 +41,7 @@ export class Tool {
       // Map the reference sites to sequential and protein sites
       tool.data[dataset].mut_metric_df = tool.data[dataset].mut_metric_df.map(
         (e) => {
+          const condition = e.condition ? e.condition.toString() : "default";
           return {
             ...e,
             site: siteMap[e.reference_site].sequential_site,
@@ -40,7 +49,7 @@ export class Tool {
             site_protein: siteMap[e.reference_site].protein_site,
             site_chain: siteMap[e.reference_site].chains,
             metric: e[metric],
-            condition: e.condition.toString(),
+            condition: condition,
           };
         }
       );
@@ -284,7 +293,7 @@ export class Tool {
     // Update the chart and deselect all sites
     tool.chart.deselectSites();
     tool.chart.updateVis();
-    tool.legend.updateVis();
+    tool.legend.updateLegend();
 
     // Only update the protein if the structure has changed
     if (tool.data[tool.dataset].pdb !== tool.protein.config.pdbID) {

--- a/src/tool.js
+++ b/src/tool.js
@@ -77,6 +77,7 @@ export class Tool {
         dataset: tool.dataset,
         proteinCondition: tool.proteinCondition,
         chartConditions: tool.chartConditions,
+        prefix: "epitope",
       },
       tool.data
     );

--- a/src/tool.js
+++ b/src/tool.js
@@ -22,8 +22,8 @@ export class Tool {
 
     // Format the data for each dataset in the JSON file
     for (const dataset in tool.data) {
-      // Get the epitopes for the dataset and convert to strings
-      tool.data[dataset].epitopes = tool.data[dataset].epitopes.map((e) =>
+      // Get the conditions for the dataset and convert to strings
+      tool.data[dataset].conditions = tool.data[dataset].conditions.map((e) =>
         e.toString()
       );
       // Get the map for reference sites to sequential sites
@@ -40,7 +40,7 @@ export class Tool {
             site_protein: siteMap[e.reference_site].protein_site,
             site_chain: siteMap[e.reference_site].chains,
             metric: e[metric],
-            epitope: e.epitope.toString(),
+            condition: e.condition.toString(),
           };
         }
       );
@@ -60,7 +60,7 @@ export class Tool {
       {
         parentElement: "#chart",
         dataset: tool.dataset,
-        chartEpitopes: tool.chartEpitopes,
+        chartConditions: tool.chartConditions,
         summary: tool.summary,
         floor: tool.floor,
         metric: tool.data[tool.dataset].metric_col,
@@ -75,8 +75,8 @@ export class Tool {
       {
         parentElement: "#legend",
         dataset: tool.dataset,
-        proteinEpitope: tool.proteinEpitope,
-        chartEpitopes: tool.chartEpitopes,
+        proteinCondition: tool.proteinCondition,
+        chartConditions: tool.chartConditions,
       },
       tool.data
     );
@@ -86,7 +86,7 @@ export class Tool {
       {
         parentElement: "viewport",
         dataset: tool.dataset,
-        proteinEpitope: tool.proteinEpitope,
+        proteinCondition: tool.proteinCondition,
         summary: tool.summary,
         floor: tool.floor,
         pdbID: tool.data[tool.dataset].pdb,
@@ -247,13 +247,13 @@ export class Tool {
     tool.chart.config.dataset = tool.dataset;
     tool.protein.config.dataset = tool.dataset;
     tool.legend.config.dataset = tool.dataset;
-    // Update the epitope selection because datasets have different epitopes
-    tool.chartEpitopes = tool.data[tool.dataset].epitopes;
-    tool.proteinEpitope = tool.chartEpitopes[0];
-    tool.chart.config.chartEpitopes = tool.chartEpitopes;
-    tool.legend.config.chartEpitopes = tool.chartEpitopes;
-    tool.protein.config.proteinEpitope = tool.proteinEpitope;
-    tool.legend.config.proteinEpitope = tool.proteinEpitope;
+    // Update the condition selection because datasets have different conditions
+    tool.chartConditions = tool.data[tool.dataset].conditions;
+    tool.proteinCondition = tool.chartConditions[0];
+    tool.chart.config.chartConditions = tool.chartConditions;
+    tool.legend.config.chartConditions = tool.chartConditions;
+    tool.protein.config.proteinCondition = tool.proteinCondition;
+    tool.legend.config.proteinCondition = tool.proteinCondition;
     // Update the filters
     tool.filters = {};
     if (tool.data[tool.dataset].filter_cols) {
@@ -339,12 +339,12 @@ export class Tool {
   /**
    * Handle updates to which eptiope is shown on the protein
    */
-  updateProteinEpitope(epitope) {
+  updateProteinCondition(condition) {
     let tool = this;
 
     // Update the config
-    tool.proteinEpitope = epitope;
-    tool.protein.config.proteinEpitope = epitope;
+    tool.proteinCondition = condition;
+    tool.protein.config.proteinCondition = condition;
 
     // Update the chart and protein
     tool.protein.updateData();
@@ -354,12 +354,12 @@ export class Tool {
   /**
    * Handle updates to which eptiopes are displayed on the chart
    */
-  updateChartEpitopes(epitopes) {
+  updateChartConditions(conditions) {
     let tool = this;
 
     // Update the config
-    tool.chartEpitopes = epitopes;
-    tool.chart.config.chartEpitopes = epitopes;
+    tool.chartConditions = conditions;
+    tool.chart.config.chartConditions = conditions;
 
     // Update the chart and protein
     tool.chart.updateVis();
@@ -400,14 +400,14 @@ export class Tool {
     // Defaults for the tool's state
     tool.defaultParams = {
       dataset: { abbrev: "e", default: tool.dataset, json: false },
-      proteinEpitope: {
+      proteinCondition: {
         abbrev: "pe",
-        default: tool.data[tool.dataset].epitopes[0],
+        default: tool.data[tool.dataset].conditions[0],
         json: false,
       },
-      chartEpitopes: {
+      chartConditions: {
         abbrev: "ce",
-        default: tool.data[tool.dataset].epitopes,
+        default: tool.data[tool.dataset].conditions,
         json: true,
       },
       summary: { abbrev: "s", default: "sum", json: false },

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 
 // Summarize metric data
 export function summarizeMetricData(data) {
-  // Calculate summary stats for each site/epitope pair
+  // Calculate summary stats for each site/condition pair
   const metricDataRollup = d3.rollup(
     data,
     (v) => {
@@ -22,27 +22,27 @@ export function summarizeMetricData(data) {
       };
     },
     (d) => d.site,
-    (d) => d.epitope
+    (d) => d.condition
   );
 
   // Join the map of summarized metric back to the original
   const metricDataSummary = data
     .map((e) => {
       return {
-        epitope: e.epitope,
+        condition: e.condition,
         site: e.site,
         site_reference: e.site_reference,
         site_protein: e.site_protein,
         site_chain: e.site_chain,
         wildtype: e.wildtype,
-        ...metricDataRollup.get(e.site).get(e.epitope),
+        ...metricDataRollup.get(e.site).get(e.condition),
       };
     })
     .filter(
       (element, index, self) =>
         index ===
         self.findIndex(
-          (e) => e.site === element.site && e.epitope === element.epitope
+          (e) => e.site === element.site && e.condition === element.condition
         )
     );
 


### PR DESCRIPTION
This pull request introduces an enhancement that increases the flexibility of the data handling process by removing the previous mandatory 'Epitope' specification. This change improves adaptability to datasets with varying formats.

Previously, 'Epitopes' played a key role in differentiating between multiple measurements for a single mutation. With this update, this need for differentiation is addressed in a more generalized manner, taking into account that datasets can have single or multiple measurements, and that those measurements might have nothing to do with ‘Epitopes’. 

Specifically, for datasets with only a single measurement per mutation, it is no longer necessary to include a distinguishing column. If multiple measurements exist per mutation, users can now specify any column in their dataset to serve as the 'condition' column. This 'condition' column takes on the role previously filled by 'Epitope', providing differentiation where necessary.

What's more, this change introduces the freedom for users to name the 'condition' column as they wish, further increasing the customization level and adaptability to various datasets.

This approach reduces the constraints on the data format, making the visualization adaptable to a wider range of user data.
