### PR TITLE
Replace color inversion with color complement

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -49,13 +49,64 @@ export function summarizeMetricData(data) {
   return metricDataSummary;
 }
 
-// Find the complement of a hex color string
+// Calculate the complement color of a given hex color
 export function invertColor(hexColor) {
-  const hex = hexColor.replace("#", "");
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-  const complement =
-    "#" + ((0xffffff ^ ((r << 16) | (g << 8) | b)) >>> 0).toString(16);
-  return complement;
+  // Convert hex to RGB
+  let r = parseInt(hexColor.slice(1, 3), 16);
+  let g = parseInt(hexColor.slice(3, 5), 16);
+  let b = parseInt(hexColor.slice(5, 7), 16);
+
+  // Convert RGB to HSL
+  (r /= 255), (g /= 255), (b /= 255);
+  let max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  let h,
+    s,
+    l = (max + min) / 2;
+  if (max == min) {
+    h = s = 0; // achromatic
+  } else {
+    let d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  // Calculate complement hue and convert HSL back to RGB
+  h = (h + 0.5) % 1;
+  let r1, g1, b1;
+  if (s == 0) {
+    r1 = g1 = b1 = l; // achromatic
+  } else {
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r1 = hue2rgb(p, q, h + 1 / 3);
+    g1 = hue2rgb(p, q, h);
+    b1 = hue2rgb(p, q, h - 1 / 3);
+  }
+
+  // Convert RGB back to hex
+  const toHex = (x) => {
+    const hex = Math.round(x * 255).toString(16);
+    return hex.length == 1 ? "0" + hex : hex;
+  };
+  return "#" + toHex(r1) + toHex(g1) + toHex(b1);
 }


### PR DESCRIPTION
The previous function that I was using to calculate a color to represent negative values in the heatmap took the inverse of a color. However, the complement provides a better visual contrast. Also, certain hex colors were getting turned to black because of rounding errors. This no longer happens with the new function. 