### PR TITLE
Show all non-carbon hydrogens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,11 +188,12 @@
 ### Added
 
 - Added the ability to show non-carbon bonded hydrogens.
+- Added the ability to color the protein by element color.
 
 ### Changed
 
 - Don't show hydrogens by default in the structure.
-- Increased the default radiusSize for ball+stick on ligands
+- Increased the default radiusScale for ball+stick on ligands to make them more visible
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,3 +182,22 @@
 ### Removed
 
 - N/A
+
+## [0.2.8] - 2023-09-28
+
+### Added
+
+- Added the ability to show non-carbon bonded hydrogens.
+
+### Changed
+
+- Don't show hydrogens by default in the structure.
+- Increased the default radiusSize for ball+stick on ligands
+
+### Deprecated
+
+- N/A
+
+### Removed
+
+- N/A

--- a/v0/index.html
+++ b/v0/index.html
@@ -287,6 +287,16 @@
                   />
                 </label>
               </div>
+              <div class="accordion-option">
+                <label for="showNonCarbonHydrogens"
+                  >Show Non-Carbon Hydrogens
+                  <input
+                    type="checkbox"
+                    name="showNonCarbonHydrogens"
+                    id="showNonCarbonHydrogens"
+                  />
+                </label>
+              </div>
             </div>
           </div>
           <!-- Filter Options -->

--- a/v0/index.html
+++ b/v0/index.html
@@ -242,6 +242,17 @@
                 <input type="color" id="ligandColor" />
               </div>
               <div class="accordion-option">
+                <label for="proteinElement"
+                  >Color Protein By Element
+                  <input
+                    type="checkbox"
+                    name="proteinElement"
+                    id="proteinElement"
+                  />
+                </label>
+              </div>
+
+              <div class="accordion-option">
                 <label for="ligandElement"
                   >Color Ligands By Element
                   <input

--- a/v0/js/main.js
+++ b/v0/js/main.js
@@ -358,6 +358,10 @@ function setUpProteinOptionListeners() {
     this.value = this.checked ? "true" : "false";
     State.updateProteinOptions(this);
   });
+  d3.select("#showNonCarbonHydrogens").on("change", function () {
+    this.value = this.checked ? "true" : "false";
+    State.updateProteinOptions(this);
+  });
 }
 
 // Set up the event listeners for the download buttons

--- a/v0/js/main.js
+++ b/v0/js/main.js
@@ -341,6 +341,10 @@ function setUpProteinOptionListeners() {
     this.value = this.checked ? "true" : "false";
     State.updateProteinOptions(this);
   });
+  d3.select("#proteinElement").on("change", function () {
+    this.value = this.checked ? "true" : "false";
+    State.updateProteinOptions(this);
+  });
   d3.select("#backgroundOpacity").on("input", function () {
     State.updateProteinOptions(this);
   });

--- a/v0/js/protein.js
+++ b/v0/js/protein.js
@@ -162,7 +162,9 @@ export class Protein {
         ? `(${protein.dataChainSelection} and not hydrogen)` +
           protein.#makeNonCarbonHydrogenSelection(protein.dataChainSelection)
         : `(${protein.dataChainSelection} and not hydrogen)`,
-      color: protein.config.proteinColor,
+      color: protein.config.proteinElement
+        ? "element"
+        : protein.config.proteinColor,
       opacity: protein.config.proteinOpacity,
       name: "dataChains",
       smoothSheet: true,
@@ -198,6 +200,8 @@ export class Protein {
           : protein.config.ligandColor,
         name: "ligands",
         multipleBond: "symmetric",
+        radiusScale:
+          protein.config.ligandRepresentation == "ball+stick" ? 1.5 : 1,
       });
     }
     protein.stage.getRepresentationsByName("nucleotide_cartoon").dispose();

--- a/v0/js/tool.js
+++ b/v0/js/tool.js
@@ -121,6 +121,7 @@ export class Tool {
         backgroundColor: tool.backgroundColor,
         ligandColor: tool.ligandColor,
         ligandElement: tool.ligandElement,
+        proteinElement: tool.proteinElement,
         backgroundOpacity: tool.backgroundOpacity,
         proteinOpacity: tool.proteinOpacity,
         selectionOpacity: tool.selectionOpacity,
@@ -176,6 +177,7 @@ export class Tool {
     tool.initColorPicker(d3.select("#backgroundColor"), tool.backgroundColor);
     tool.initColorPicker(d3.select("#ligandColor"), tool.ligandColor);
     tool.initCheckbox(d3.select("#ligandElement"), tool.ligandElement);
+    tool.initCheckbox(d3.select("#proteinElement"), tool.proteinElement);
     tool.initRange(d3.select("#proteinOpacity"), tool.proteinOpacity);
     tool.initRange(d3.select("#selectionOpacity"), tool.selectionOpacity);
     tool.initRange(d3.select("#backgroundOpacity"), tool.backgroundOpacity);
@@ -537,6 +539,7 @@ export class Tool {
       backgroundColor: { abbrev: "bc", default: "#d3d3d3", json: false },
       ligandColor: { abbrev: "lc", default: "#d3d3d3", json: false },
       ligandElement: { abbrev: "le", default: false, json: false },
+      proteinElement: { abbrev: "pce", default: false, json: false },
       proteinOpacity: { abbrev: "po", default: "1", json: false },
       selectionOpacity: { abbrev: "so", default: "1", json: false },
       backgroundOpacity: { abbrev: "bo", default: "1", json: false },

--- a/v0/js/tool.js
+++ b/v0/js/tool.js
@@ -126,6 +126,7 @@ export class Tool {
         selectionOpacity: tool.selectionOpacity,
         showGlycans: tool.showGlycans,
         showNucleotides: tool.showNucleotides,
+        showNonCarbonHydrogens: tool.showNonCarbonHydrogens,
       },
       tool.data
     );
@@ -167,6 +168,10 @@ export class Tool {
     );
     tool.initCheckbox(d3.select("#showGlycans"), tool.showGlycans);
     tool.initCheckbox(d3.select("#showNucleotides"), tool.showNucleotides);
+    tool.initCheckbox(
+      d3.select("#showNonCarbonHydrogens"),
+      tool.showNonCarbonHydrogens
+    );
     tool.initColorPicker(d3.select("#proteinColor"), tool.proteinColor);
     tool.initColorPicker(d3.select("#backgroundColor"), tool.backgroundColor);
     tool.initColorPicker(d3.select("#ligandColor"), tool.ligandColor);
@@ -537,6 +542,7 @@ export class Tool {
       backgroundOpacity: { abbrev: "bo", default: "1", json: false },
       showGlycans: { abbrev: "g", default: false, json: false },
       showNucleotides: { abbrev: "n", default: false, json: false },
+      showNonCarbonHydrogens: { abbrev: "h", default: false, json: false },
       filters: {
         abbrev: "fi",
         default: tool.data[tool.dataset].filter_cols


### PR DESCRIPTION
I removed the default behavior that showed hydrogens in every structure if they were present on the protein. This makes the visualization more consistent between structures. I also added a feature that makes it possible to show hydrogen atoms that aren't bonded to carbons. This can be useful for users interested in hydrogen bonding – for example hydrogen bonds to a therjpuetic ligand. 