### PR TITLE
Enable the heatmap's color scale to be non-symmetric with custom center and range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -496,3 +496,21 @@
 ### Removed
 
 - N/A
+
+## [0.7.0] - 2024-05-15
+
+### Added
+
+- Allow users to set the min, max, and center of the color scales.
+
+### Changed
+
+- N/A
+
+### Deprecated
+
+- N/A
+
+### Removed
+
+- N/A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,10 +502,11 @@
 ### Added
 
 - Allow users to set the min, max, and center of the color scales.
+- Allow for color scales that aren't symmetric around 0.
 
 ### Changed
 
-- N/A
+- Clear the URI parameters when data is loaded from a local file.
 
 ### Deprecated
 

--- a/v0/js/chart.js
+++ b/v0/js/chart.js
@@ -630,14 +630,14 @@ export class Chart {
         .domain([vis.heatmapCenter, vis.heatmapMax])
         .range(["white", vis.positiveColor]);
     }
-    // vis.legendScaleHeatmap
-    //   .domain(vis.colorScaleHeatmap.domain())
-    //   .rangeRound(
-    //     d3.quantize(
-    //       d3.interpolate(vis.bounds.heatmap.height / 2, 0),
-    //       vis.colorScaleHeatmap.range().length
-    //     )
-    //   );
+    vis.legendScaleHeatmap
+      .domain(vis.colorScaleHeatmap.domain())
+      .rangeRound(
+        d3.quantize(
+          d3.interpolate(vis.bounds.heatmap.height / 2, 0),
+          vis.colorScaleHeatmap.range().length
+        )
+      );
 
     // define a function to make the tooltip html
     vis.tooltipContent = (d) => {
@@ -926,7 +926,12 @@ export class Chart {
       .attr("stop-color", (d) => vis.colorScaleHeatmap(d));
 
     vis.yAxisHeatmapLegendG
-      .call(vis.yAxisHeatmapLegend)
+      .call(
+        vis.yAxisHeatmapLegend.tickValues([
+          vis.colorScaleHeatmap.domain()[0],
+          vis.colorScaleHeatmap.domain()[2],
+        ])
+      )
       .call((g) => g.select(".domain").remove());
 
     vis.brushSelection = vis.brushSelection || null;

--- a/v0/js/chart.js
+++ b/v0/js/chart.js
@@ -328,10 +328,7 @@ export class Chart {
     vis.yAxisHeatmapG = vis.heatmapPlot
       .append("g")
       .attr("class", "axis y-axis");
-    vis.yAxisHeatmapLegend = d3
-      .axisRight(vis.legendScaleHeatmap)
-      .ticks(3)
-      .tickSize(0);
+    vis.yAxisHeatmapLegend = d3.axisRight(vis.legendScaleHeatmap).tickSize(0);
     vis.yAxisHeatmapLegendG = vis.heatmapLegend
       .append("g")
       .attr("transform", `translate(${vis.bounds.heatmap.width / 2})`)
@@ -630,14 +627,19 @@ export class Chart {
         .domain([vis.heatmapCenter, vis.heatmapMax])
         .range(["white", vis.positiveColor]);
     }
+
+    // Calculate the legend positions
+    const legendPositions = vis.colorScaleHeatmap.domain().map((value) => {
+      const domain = vis.colorScaleHeatmap.domain();
+      const ratio =
+        (value - domain[0]) / (domain[domain.length - 1] - domain[0]);
+      return (vis.bounds.heatmap.height / 2) * (1 - ratio);
+    });
+
+    // Create the legend scale
     vis.legendScaleHeatmap
       .domain(vis.colorScaleHeatmap.domain())
-      .rangeRound(
-        d3.quantize(
-          d3.interpolate(vis.bounds.heatmap.height / 2, 0),
-          vis.colorScaleHeatmap.range().length
-        )
-      );
+      .range(legendPositions);
 
     // define a function to make the tooltip html
     vis.tooltipContent = (d) => {
@@ -929,7 +931,10 @@ export class Chart {
       .call(
         vis.yAxisHeatmapLegend.tickValues([
           vis.colorScaleHeatmap.domain()[0],
-          vis.colorScaleHeatmap.domain()[2],
+          vis.colorScaleHeatmap.domain()[1],
+          vis.colorScaleHeatmap.domain()[
+            vis.colorScaleHeatmap.domain().length - 1
+          ],
         ])
       )
       .call((g) => g.select(".domain").remove());

--- a/v0/js/main.js
+++ b/v0/js/main.js
@@ -216,13 +216,15 @@ function setUpFileUploadListeners() {
 
         // Update the tool's state
         State.data = removeMarkdown(data);
-        State.initTool();
 
         // Clear the URL parameters and remote UI input elements
         window.history.replaceState({}, "", `${location.pathname}`);
         document.getElementById("url-json-file").value = "";
         document.getElementById("url-markdown-file").value = "";
         document.getElementById("url-markdown-file").disabled = true;
+
+        // Update the tool state
+        State.initTool();
 
         // Check if there is a markdown description in the data
         if (data.markdown_description) {


### PR DESCRIPTION
You can now set the minimum, maximum, and center of the heatmap's color scale using the `--heatmap-limits` argument of `configure-dms-viz`.  The heatmap's default color scale is still symmetric and centered around 0. 