### PR TITLE
Fix bug with `floor` when switching datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,3 +568,21 @@
 ### Removed
 
 - N/A
+
+## [0.8.3] - 2024-06-13
+
+### Added
+
+- N/A
+
+### Changed
+
+- Fix a bug where floor was determined by the config in the chart but not for the protein.
+
+### Deprecated
+
+- N/A
+
+### Removed
+
+- N/A

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dms-viz.github.io",
   "private": true,
-  "version": "v0.8.2",
+  "version": "v0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/v0/js/tool.js
+++ b/v0/js/tool.js
@@ -405,6 +405,7 @@ export class Tool {
     );
     tool.chart.config.summary = tool.data[tool.dataset].summary_stat || "mean";
     tool.chart.config.floor = tool.data[tool.dataset].floor || false;
+    tool.protein.config.floor = tool.data[tool.dataset].floor || false;
 
     // Populate Filter Sites
     tool.filters = {};


### PR DESCRIPTION
Patch a bug where the value of `floor` wasn't being determined by the config for the protein.