### PR TITLE
Ameliorate lag in the legend UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,3 +604,21 @@
 ### Removed
 
 - N/A
+
+## [0.8.5] - 2024-07-08
+
+### Added
+
+- N/A
+
+### Changed
+
+- Make it easier to select and de-select options with double-clicking.
+
+### Deprecated
+
+- N/A
+
+### Removed
+
+- N/A

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dms-viz.github.io",
   "private": true,
-  "version": "v0.8.4",
+  "version": "v0.8.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/v0/js/legend.js
+++ b/v0/js/legend.js
@@ -111,15 +111,20 @@ export class Legend {
             .style("fill", (d) => vis.conditionColors[d])
             .on("click", (event, datum) => {
               if (event.altKey && vis.config.chartConditions.includes(datum)) {
-                vis.deselectChartConditions(datum);
+                requestAnimationFrame(() => vis.deselectChartConditions(datum));
               } else if (
                 event.altKey &&
                 !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartConditions(datum);
+                requestAnimationFrame(() => vis.selectChartConditions(datum));
               } else {
-                vis.selectProteinCondition(datum);
+                requestAnimationFrame(() => vis.selectProteinCondition(datum));
               }
+            })
+            .on("dblclick", (event, datum) => {
+              requestAnimationFrame(() =>
+                vis.clearAndSelectSingleCondition(datum)
+              );
             }),
         (update) =>
           update
@@ -150,15 +155,20 @@ export class Legend {
             )
             .on("click", (event, datum) => {
               if (event.altKey && vis.config.chartConditions.includes(datum)) {
-                vis.deselectChartConditions(datum);
+                requestAnimationFrame(() => vis.deselectChartConditions(datum));
               } else if (
                 event.altKey &&
                 !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartConditions(datum);
+                requestAnimationFrame(() => vis.selectChartConditions(datum));
               } else {
-                vis.selectProteinCondition(datum);
+                requestAnimationFrame(() => vis.selectProteinCondition(datum));
               }
+            })
+            .on("dblclick", (event, datum) => {
+              requestAnimationFrame(() =>
+                vis.clearAndSelectSingleCondition(datum)
+              );
             }),
         (update) =>
           update
@@ -192,15 +202,20 @@ export class Legend {
             .style("user-select", "none")
             .on("click", (event, datum) => {
               if (event.altKey && vis.config.chartConditions.includes(datum)) {
-                vis.deselectChartConditions(datum);
+                requestAnimationFrame(() => vis.deselectChartConditions(datum));
               } else if (
                 event.altKey &&
                 !vis.config.chartConditions.includes(datum)
               ) {
-                vis.selectChartConditions(datum);
+                requestAnimationFrame(() => vis.selectChartConditions(datum));
               } else {
-                vis.selectProteinCondition(datum);
+                requestAnimationFrame(() => vis.selectProteinCondition(datum));
               }
+            })
+            .on("dblclick", (event, datum) => {
+              requestAnimationFrame(() =>
+                vis.clearAndSelectSingleCondition(datum)
+              );
             }),
         (update) =>
           update
@@ -235,10 +250,15 @@ export class Legend {
     vis.config.proteinCondition = datum;
 
     // Dispatch an event to notify about the selected condition
-    const proteinConditionEvent = new CustomEvent("proteinConditionSelected", {
-      detail: vis.config.proteinCondition,
+    requestAnimationFrame(() => {
+      const proteinConditionEvent = new CustomEvent(
+        "proteinConditionSelected",
+        {
+          detail: vis.config.proteinCondition,
+        }
+      );
+      window.dispatchEvent(proteinConditionEvent);
     });
-    window.dispatchEvent(proteinConditionEvent);
   }
   selectChartConditions(datum) {
     let vis = this;
@@ -263,10 +283,12 @@ export class Legend {
     vis.config.chartConditions.push(datum);
 
     // Dispatch an event to notify about the plot conditions
-    const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
-      detail: vis.config.chartConditions,
+    requestAnimationFrame(() => {
+      const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
+        detail: vis.config.chartConditions,
+      });
+      window.dispatchEvent(chartConditionEvent);
     });
-    window.dispatchEvent(chartConditionEvent);
   }
   deselectChartConditions(datum) {
     let vis = this;
@@ -304,9 +326,51 @@ export class Legend {
       .style("opacity", ".25");
 
     // Dispatch an event to notify about the plot conditions
-    const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
-      detail: vis.config.chartConditions,
+    requestAnimationFrame(() => {
+      const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
+        detail: vis.config.chartConditions,
+      });
+      window.dispatchEvent(chartConditionEvent);
     });
-    window.dispatchEvent(chartConditionEvent);
+  }
+  clearAndSelectSingleCondition(datum) {
+    let vis = this;
+
+    // Clear all chartConditions and only keep the clicked datum
+    vis.config.chartConditions = [datum];
+
+    // Update protein condition to the selected datum
+    vis.config.proteinCondition = datum;
+
+    // Reset styles to reflect only the selected condition
+    vis.legend
+      .selectAll(".condition-box")
+      .style("opacity", (d) => (d === datum ? ".25" : "0"));
+
+    vis.legend
+      .selectAll(".condition-circle")
+      .style("opacity", (d) => (d === datum ? "1" : "0.2"));
+
+    vis.legend
+      .selectAll(".condition-label")
+      .style("opacity", (d) => (d === datum ? "1" : "0.2"));
+
+    // Dispatch events to notify about the selected condition
+    requestAnimationFrame(() => {
+      const chartConditionEvent = new CustomEvent("chartConditionsSelected", {
+        detail: vis.config.chartConditions,
+      });
+      window.dispatchEvent(chartConditionEvent);
+    });
+
+    requestAnimationFrame(() => {
+      const proteinConditionEvent = new CustomEvent(
+        "proteinConditionSelected",
+        {
+          detail: vis.config.proteinCondition,
+        }
+      );
+      window.dispatchEvent(proteinConditionEvent);
+    });
   }
 }


### PR DESCRIPTION
There is a significant amount of lag when selecting conditions on the chart. Some of this has to do with the logic of the application. This pull request does the following:

1. The legend is automatically updated by requesting animation frames before updating the application state.
2. Selecting single conditions is expedited by adding an event listener for `double-click` events.


The consequence of these changes is that the legend appears less laggy and the user can select a single condition while deselecting all others by `double-clicking` on that condition in the legend.